### PR TITLE
Make register_buffer and register_parameter public

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -96,9 +96,7 @@ TEST_F(ModuleTest, RegisterModuleThrowsForDuplicateModuleName) {
 }
 
 TEST_F(ModuleTest, RegisterParameterThrowsForEmptyOrDottedName) {
-  struct TestModel : public torch::nn::Module {
-    using torch::nn::Module::register_parameter;
-  };
+  struct TestModel : public torch::nn::Module {};
   ASSERT_THROWS_WITH(
       TestModel{}.register_parameter("name.with.dot", torch::ones(5)),
       "Parameter name must not contain a dot (got 'name.with.dot')");
@@ -108,9 +106,7 @@ TEST_F(ModuleTest, RegisterParameterThrowsForEmptyOrDottedName) {
 }
 
 TEST_F(ModuleTest, RegisterParameterThrowsForDuplicateModuleName) {
-  struct TestModel : public torch::nn::Module {
-    using torch::nn::Module::register_parameter;
-  };
+  struct TestModel : public torch::nn::Module {};
   TestModel model;
   model.register_parameter("p", torch::ones(5));
   ASSERT_THROWS_WITH(
@@ -119,9 +115,7 @@ TEST_F(ModuleTest, RegisterParameterThrowsForDuplicateModuleName) {
 }
 
 TEST_F(ModuleTest, RegisterBufferThrowsForEmptyOrDottedName) {
-  struct TestModel : public torch::nn::Module {
-    using torch::nn::Module::register_buffer;
-  };
+  struct TestModel : public torch::nn::Module {};
   ASSERT_THROWS_WITH(
       TestModel{}.register_buffer("name.with.dot", torch::ones(5)),
       "Buffer name must not contain a dot (got 'name.with.dot')");
@@ -131,9 +125,7 @@ TEST_F(ModuleTest, RegisterBufferThrowsForEmptyOrDottedName) {
 }
 
 TEST_F(ModuleTest, RegisterBufferThrowsForDuplicateModuleName) {
-  struct TestModel : public torch::nn::Module {
-    using torch::nn::Module::register_buffer;
-  };
+  struct TestModel : public torch::nn::Module {};
   TestModel model;
   model.register_buffer("p", torch::ones(5));
   ASSERT_THROWS_WITH(

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -57,7 +57,7 @@ namespace nn {
 ///
 /// Parameters are registered with a `Module` via `register_parameter`. Buffers
 /// are registered separately via `register_buffer`. These methods are part of
-/// the protected API of `Module` and are typically invoked from within a
+/// the public API of `Module` and are typically invoked from within a
 /// concrete `Module`s constructor.
 class TORCH_API Module : public std::enable_shared_from_this<Module> {
  public:
@@ -290,6 +290,39 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
       std::string name,
       ModuleHolder<ModuleType> module_holder);
 
+  /// Registers a parameter with this `Module`.
+  ///
+  /// A parameter should be any gradient-recording tensor used in the
+  /// implementation of your `Module`. Registering it makes it available to
+  /// methods such as `parameters()`, `clone()` or `to().`
+  ///
+  /// \rst
+  /// .. code-block:: cpp
+  ///
+  ///   MyModule::MyModule() {
+  ///     weight_ = register_parameter("weight", torch::randn({A, B}));
+  ///   }
+  /// \endrst
+  Tensor& register_parameter(
+      std::string name,
+      Tensor tensor,
+      bool requires_grad = true);
+
+  /// Registers a buffer with this `Module`.
+  ///
+  /// A buffer is intended to be state in your module that does not record
+  /// gradients, such as running statistics. Registering it makes it available
+  /// to methods such as `buffers()`, `clone()` or `to().
+  ///
+  /// \rst
+  /// .. code-block:: cpp
+  ///
+  ///   MyModule::MyModule() {
+  ///     mean_ = register_buffer("mean", torch::empty({num_features_}));
+  ///   }
+  /// \endrst
+  Tensor& register_buffer(std::string name, Tensor tensor);
+
   /// Enables "training" mode.
   virtual void train(bool on = true);
 
@@ -441,40 +474,6 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
 
   /// Returns whether the `Module` is serializable.
   virtual bool is_serializable() const;
-
- protected:
-  /// Registers a parameter with this `Module`.
-  ///
-  /// A parameter should be any gradient-recording tensor used in the
-  /// implementation of your `Module`. Registering it makes it available to
-  /// methods such as `parameters()`, `clone()` or `to().`
-  ///
-  /// \rst
-  /// .. code-block:: cpp
-  ///
-  ///   MyModule::MyModule() {
-  ///     weight_ = register_parameter("weight", torch::randn({A, B}));
-  ///   }
-  /// \endrst
-  Tensor& register_parameter(
-      std::string name,
-      Tensor tensor,
-      bool requires_grad = true);
-
-  /// Registers a buffer with this `Module`.
-  ///
-  /// A buffer is intended to be state in your module that does not record
-  /// gradients, such as running statistics. Registering it makes it available
-  /// to methods such as `buffers()`, `clone()` or `to().
-  ///
-  /// \rst
-  /// .. code-block:: cpp
-  ///
-  ///   MyModule::MyModule() {
-  ///     mean_ = register_buffer("mean", torch::empty({num_features_}));
-  ///   }
-  /// \endrst
-  Tensor& register_buffer(std::string name, Tensor tensor);
 
  private:
   // Friend classes.


### PR DESCRIPTION
In python `register_buffer` and `register_parameter` in `nn.Module` are also public, according to the documentation. I have mentioned it in https://github.com/pytorch/pytorch/issues/23140#issuecomment-514072221.

 I took the liberty of modifying these two member functions to public, and I wish it is helpful.