### PR TITLE
add meta support to operators

### DIFF
--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -95,6 +95,7 @@ enum class ConvBackend {
   Cudnn,
   CudnnTranspose,
   Empty,
+  Meta,
   Miopen,
   MiopenDepthwise,
   MiopenTranspose,

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -267,6 +267,10 @@ Tensor & _cat_out_cpu(TensorList tensors, int64_t dim, Tensor& result) {
     return result;
   }
 
+  if (result.device() == kMeta) {
+    return result;
+  }
+
   // fast path for single thread when both inputs and result are contiguous and not empty
   allContiguous = allContiguous && result.is_contiguous(first_tensor_mem_format);
   bool use_serial_kernel = result.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1;
@@ -333,7 +337,20 @@ Tensor & _cat_out_cpu(TensorList tensors, int64_t dim, Tensor& result) {
 
 Tensor _cat_cpu(TensorList tensors, int64_t dim) {
   ScalarType high_type = result_type(tensors);
-  Tensor result = at::empty({0}, tensors[0].options().dtype(high_type));
+  bool use_meta_tensor = false;
+  for (const auto i : c10::irange(tensors.size())) {
+    auto const &t = tensors[i];
+    if (t.device() == kMeta) {
+      use_meta_tensor = true;
+      break;
+    }
+  }
+  Tensor result;
+  if (use_meta_tensor) {
+    result = at::empty({0}, tensors[0].options().dtype(high_type).device(kMeta));
+  } else {
+    result = at::empty({0}, tensors[0].options().dtype(high_type));
+  }
   return native::_cat_out_cpu(tensors, dim, result);
 }
 
@@ -2100,7 +2117,11 @@ Tensor _unsafe_view(const Tensor& self, IntArrayRef size) {
 Tensor unsqueeze(const Tensor& self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim() + 1);
   auto g = inferUnsqueezeGeometry(self, dim);
-  return self.as_strided(g.sizes, g.strides);
+  if (self.device() == kMeta) {
+    return at::empty(g.sizes, self.options().device(kMeta));
+  } else {
+    return self.as_strided(g.sizes, g.strides);
+  }
 }
 
 Tensor unsqueeze_sparse(Tensor const &self, int64_t dim) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3269,7 +3269,7 @@
 
 - func: native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)
   dispatch:
-    CPU: batch_norm_cpu
+    CPU, Meta: batch_norm_cpu
     CUDA: batch_norm_cuda
     MkldnnCPU: mkldnn_batch_norm
 
@@ -3300,7 +3300,7 @@
 
 - func: native_batch_norm_backward(Tensor grad_out, Tensor input, Tensor? weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_invstd, bool train, float eps, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   dispatch:
-    CPU: batch_norm_backward_cpu
+    CPU, Meta: batch_norm_backward_cpu
     CUDA: batch_norm_backward_cuda
     MkldnnCPU: mkldnn_batch_norm_backward
 
@@ -4692,7 +4692,7 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    CPU, CUDA: unsqueeze
+    CPU, CUDA, Meta: unsqueeze
     SparseCPU, SparseCUDA: unsqueeze_sparse
     QuantizedCPU, QuantizedCUDA: unsqueeze_quantized
 
@@ -7871,13 +7871,13 @@
 
 - func: _cat(Tensor[] tensors, int dim=0) -> Tensor
   dispatch:
-    CPU: _cat_cpu
+    CPU, Meta: _cat_cpu
     CUDA: cat_cuda
     QuantizedCPU: cat_quantized_cpu
 
 - func: _cat.out(Tensor[] tensors, int dim=0, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU: _cat_out_cpu
+    CPU, Meta: _cat_out_cpu
     CUDA: cat_out_cuda
     QuantizedCPU: cat_out_quantized_cpu
 


### PR DESCRIPTION
Add meta tensor support to the following operators:
- `unsqueeze`
- `convolution_overrideable`
- `cat`
- `layer_norm` (by adding meta support to `native_batch_norm`)

Note that I didn't add the proper structured kernel support yet, but the following notes might be useful:
- `convolution_overrideable` - optional Tensor support is no longer a blocker, see pytorch pull 55503
- `cat` - blocked on Tensor list support? dig around
- `layer_norm` (optional Tensor support is no longer a blocker, see pytorch pull 55503) (also there is already a PR for `native_batch_norm`: pytorch pull 67343)

-----

References:
- Guide: https://github.com/pytorch/rfcs/blob/rfc-0005/RFC-0005-structured-kernel-definitions.md
- Examples:
  - pytorch pull 72124
  - pytorch issues 55070
  - https://github.com/pytorch/pytorch/pulls?q=is%3Apr+is%3Aopen+structured+in%3Atitle

Phase 1: meta tensor, no structured kernel
- [Advice]
  - You will simply "shortcut" unsqueeze operator and just return a meta tensor after inferring the shape and layout of the tensor before running anything else. e.g. https://github.com/pytorch/pytorch/pull/67032/files#diff-a1d9f0dda9e567690f083fa5793404d973be506b176ec8b251064dff54484dfdR31
  - After validating some preconditions the first thing that linspace (and other range factories) does is to check the device argument, and simply return. Most of the time non-factory operators can use the same trick.
  - Using structured kernel is great but could be overkill if all you need is meta support. It can become significantly more complicated than just adding an if statement.
  - tril / triu structured kernel PR: pytorch pull 67055

Phase 2: meta tensor + structured kernel
- Follow these breadcrumbs in PyTorch codebase for how to add structured kernel for operators:
  - `TORCH_META_FUNC`
  - `TORCH_IMPL_FUNC`
  - typical pattern is one TORCH_META_FUNC along with a few TORCH_IMPL_FUNCs
